### PR TITLE
fix(infra): skip husky prepare in amplify ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docker:down": "docker compose down",
     "docker:reset": "docker compose down -v && docker compose up -d",
     "docker:logs": "docker compose logs -f",
-    "prepare": "husky"
+    "prepare": "node scripts/prepare-husky.mjs"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed/index.ts"

--- a/scripts/prepare-husky.mjs
+++ b/scripts/prepare-husky.mjs
@@ -1,0 +1,18 @@
+import { execSync } from 'node:child_process';
+
+const isCiEnvironment =
+  process.env.CI === 'true' ||
+  Boolean(process.env.AWS_BRANCH) ||
+  Boolean(process.env.AMPLIFY_APP_ID);
+
+// In CI/Amplify, skip husky setup to avoid failing when devDependencies are omitted.
+if (isCiEnvironment) {
+  process.exit(0);
+}
+
+try {
+  execSync('npx husky', { stdio: 'inherit' });
+} catch {
+  // Do not block install if husky is unavailable in this environment.
+  process.exit(0);
+}


### PR DESCRIPTION
## Resumen\n- Evita fallo de Amplify en npm ci por script prepare\n- Reemplaza prepare por script robusto para CI/Amplify\n\n## Cambios\n- package.json\n- scripts/prepare-husky.mjs\n\n## Motivo\nAmplify fallaba con: husky: command not found (exit code 127).