### PR TITLE
fix(infra): prisma generate without dotenv in amplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docker:down": "docker compose down",
     "docker:reset": "docker compose down -v && docker compose up -d",
     "docker:logs": "docker compose logs -f",
-    "prepare": "husky"
+    "prepare": "node scripts/prepare-husky.mjs"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed/index.ts"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,12 +4,23 @@
 // @see https://pris.ly/prisma-config
 
 import path from 'node:path';
+import { createRequire } from 'node:module';
 
-import { config as loadDotenv } from 'dotenv';
 import { defineConfig } from 'prisma/config';
 
-// prisma.config.ts no carga .env.local automáticamente → cargar de forma explícita
-loadDotenv({ path: '.env.local' });
+const require = createRequire(import.meta.url);
+
+// En CI/Amplify, las variables llegan por entorno y dotenv puede no estar instalado.
+const shouldLoadDotenv = !process.env.CI && !process.env.AWS_BRANCH && !process.env.AMPLIFY_APP_ID;
+
+if (shouldLoadDotenv) {
+  try {
+    const { config: loadDotenv } = require('dotenv');
+    loadDotenv({ path: '.env.local' });
+  } catch {
+    // No bloquear prisma generate si dotenv no está disponible.
+  }
+}
 
 export default defineConfig({
   schema: path.join('prisma', 'schema'),

--- a/scripts/prepare-husky.mjs
+++ b/scripts/prepare-husky.mjs
@@ -1,0 +1,18 @@
+import { execSync } from 'node:child_process';
+
+const isCiEnvironment =
+  process.env.CI === 'true' ||
+  Boolean(process.env.AWS_BRANCH) ||
+  Boolean(process.env.AMPLIFY_APP_ID);
+
+// In CI/Amplify, skip husky setup to avoid failing when devDependencies are omitted.
+if (isCiEnvironment) {
+  process.exit(0);
+}
+
+try {
+  execSync('npx husky', { stdio: 'inherit' });
+} catch {
+  // Do not block install if husky is unavailable in this environment.
+  process.exit(0);
+}


### PR DESCRIPTION
## Problema\nAmplify fallaba en preBuild con npx prisma generate:\n- Cannot find module 'dotenv' desde prisma.config.ts\n\n## Solucion\n- Hacer carga de dotenv opcional en prisma.config.ts\n- En CI/Amplify no intenta cargar dotenv\n- En local mantiene carga de .env.local\n\n## Validacion\n- Ejecutado: CI=true npx prisma generate --schema=./prisma/schema\n- Resultado: OK