### PR TITLE
fix(auth): restore middleware and fix first-time user login redirect

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { Suspense, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { signIn, confirmSignIn } from 'aws-amplify/auth';
-import type { Route } from 'next';
 import { Eye, EyeOff, Loader2, AlertCircle, ShieldCheck, KeyRound } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -82,7 +81,6 @@ function getAuthErrorMessage(error: unknown): string {
 type Step = 'credentials' | 'totp' | 'new-password';
 
 function LoginContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get('from') ?? '/dashboard';
 
@@ -108,6 +106,14 @@ function LoginContent() {
     defaultValues: { password: '', confirmPassword: '' },
   });
 
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  // Full page reload garantiza que el middleware reciba los cookies recién
+  // emitidos por Amplify sin depender del timing del router de Next.js.
+  function navigateAfterSignIn() {
+    window.location.replace(redirectTo);
+  }
+
   // ── Handlers ─────────────────────────────────────────────────────────────
 
   const handleCredentialsSubmit = async (data: CredentialsForm) => {
@@ -119,8 +125,7 @@ function LoginContent() {
       });
 
       if (result.isSignedIn) {
-        router.replace(redirectTo as Route);
-        router.refresh();
+        navigateAfterSignIn();
         return;
       }
 
@@ -148,8 +153,7 @@ function LoginContent() {
       const result = await confirmSignIn({ challengeResponse: data.code });
 
       if (result.isSignedIn) {
-        router.replace(redirectTo as Route);
-        router.refresh();
+        navigateAfterSignIn();
         return;
       }
 
@@ -165,8 +169,7 @@ function LoginContent() {
       const result = await confirmSignIn({ challengeResponse: data.password });
 
       if (result.isSignedIn) {
-        router.replace(redirectTo as Route);
-        router.refresh();
+        navigateAfterSignIn();
         return;
       }
 
@@ -206,7 +209,6 @@ function LoginContent() {
                 className="space-y-4"
                 noValidate
               >
-                {/* Error general */}
                 {authError && (
                   <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2.5 text-sm text-red-700">
                     <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
@@ -214,7 +216,6 @@ function LoginContent() {
                   </div>
                 )}
 
-                {/* Email */}
                 <div className="space-y-1.5">
                   <Label htmlFor="email">Correo electrónico</Label>
                   <Input
@@ -232,7 +233,6 @@ function LoginContent() {
                   )}
                 </div>
 
-                {/* Contraseña */}
                 <div className="space-y-1.5">
                   <Label htmlFor="password">Contraseña</Label>
                   <div className="relative">
@@ -261,7 +261,6 @@ function LoginContent() {
                   )}
                 </div>
 
-                {/* Submit */}
                 <Button
                   type="submit"
                   className="w-full"
@@ -297,7 +296,6 @@ function LoginContent() {
                 className="space-y-4"
                 noValidate
               >
-                {/* Error general */}
                 {authError && (
                   <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2.5 text-sm text-red-700">
                     <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
@@ -305,7 +303,6 @@ function LoginContent() {
                   </div>
                 )}
 
-                {/* Código TOTP */}
                 <div className="space-y-1.5">
                   <Label htmlFor="code">Código de autenticación</Label>
                   <Input
@@ -326,7 +323,6 @@ function LoginContent() {
                   )}
                 </div>
 
-                {/* Submit */}
                 <Button type="submit" className="w-full" disabled={totpForm.formState.isSubmitting}>
                   {totpForm.formState.isSubmitting ? (
                     <>
@@ -350,7 +346,7 @@ function LoginContent() {
               </form>
             </CardContent>
           </>
-        ) : step === 'new-password' ? (
+        ) : (
           <>
             <CardHeader className="pb-4">
               <div className="mb-1 flex items-center gap-2">
@@ -424,7 +420,7 @@ function LoginContent() {
               </form>
             </CardContent>
           </>
-        ) : null}
+        )}
       </Card>
 
       {/* Footer */}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as middleware, config } from './proxy';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as middleware, config } from './proxy';


### PR DESCRIPTION
## Problema

Los usuarios de primer acceso (estado `FORCE_CHANGE_PASSWORD` en Cognito) quedaban atrapados en el login después de cambiar su contraseña temporal. El sistema no los redirigía al dashboard correctamente.

## Causa raíz — 3 bugs combinados

### 1. `src/middleware.ts` fue eliminado sin reemplazo (crítico)

En el PR #24 se agregó `src/proxy.ts` con la lógica correcta del middleware (incluyendo `buildLoginRedirect`), pero `src/middleware.ts` fue eliminado sin crear un archivo que lo reexportara. **Next.js únicamente reconoce `src/middleware.ts` como entry point** — `proxy.ts` era código muerto.

Consecuencia: ningún middleware corría en staging. Las rutas `/dashboard/*` y `/api/v1/*` no recibían los headers `x-company-id` / `x-user-id`, el TenantContext fallaba con 401, y el dashboard se veía completamente roto para usuarios sin caché en `localStorage`.

### 2. Step `new-password` ausente en staging

El PR #24 fue mergeado a `main` pero **no a `staging`**. La versión del login page en staging solo manejaba `credentials` y `totp`. Al recibir el challenge `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED`, el usuario veía "Se requiere una acción adicional. Contacta al administrador." en lugar del formulario de cambio de contraseña.

### 3. Race condition en el redirect post-login

`router.replace(redirectTo) + router.refresh()` tiene un problema de timing: la navegación soft de Next.js puede alcanzar el middleware antes de que Amplify termine de escribir los tokens a `document.cookie`. El middleware no encontraba el cookie y redirigía de vuelta a `/login?from=/dashboard`.

## Fix

| Archivo | Cambio |
|---|---|
| `src/middleware.ts` | **Nuevo** — re-exporta `proxy as middleware, config` desde `./proxy` |
| `src/app/(auth)/login/page.tsx` | Agrega step `new-password` completo (schema, form, handler). Reemplaza `router.replace + router.refresh` por `window.location.replace` en todos los paths post-signIn |

`window.location.replace` fuerza un full page reload, garantizando que el browser envíe todos los cookies recién escritos en el `Cookie` header del siguiente request al servidor.

## Flujo corregido

```
signIn() → CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED
         → step 'new-password' (form visible)
         → confirmSignIn(newPassword)
         → isSignedIn: true
         → window.location.replace('/dashboard')   ← full reload con cookies
         → middleware verifica token ✓
         → dashboard carga correctamente ✓
```

## Testing

- [ ] Crear usuario en Cognito console con contraseña temporal (estado `FORCE_CHANGE_PASSWORD`)
- [ ] Iniciar sesión → debe aparecer el formulario "Establecer nueva contraseña"
- [ ] Ingresar nueva contraseña → debe redirigir al dashboard sin loop
- [ ] Verificar que usuarios existentes (login normal) siguen funcionando
- [ ] Verificar que el flujo TOTP sigue funcionando

## Notas para el reviewer

- La eliminación de `middleware.ts` afecta **todos** los usuarios, no solo los de primer acceso. Los usuarios existentes con caché en `localStorage` no notaban el problema porque el TenantProvider mostraba datos cacheados aunque el API fallara en background.
- Este PR debe mergearse a `staging` antes que cualquier otra rama que dependa de auth.