### PR TITLE
fix(auth): restore middleware.ts so Next.js runs proxy.ts as middleware

### DIFF
--- a/src/__tests__/integration/publish-flow.test.ts
+++ b/src/__tests__/integration/publish-flow.test.ts
@@ -54,7 +54,7 @@ const IDS = {
   fiscalYear: '00000000-0000-0000-0005-000000000060',
   fiscalPeriodMar: '00000000-0000-0000-0005-000000000070',
   // Período de Abril — necesario para que cancelInvoice cree el asiento de reversión
-  // (cancelInvoice busca un período OPEN para "hoy", y hoy es 2026-04-01)
+  // (cancelInvoice busca un período OPEN para "hoy"; cubre Apr-Dic 2026)
   fiscalPeriodApr: '00000000-0000-0000-0005-000000000071',
   accountAR: '00000000-0000-0000-0005-000000000080', // 1103
   accountISV: '00000000-0000-0000-0005-000000000081', // 2102
@@ -238,7 +238,7 @@ beforeAll(async () => {
     }),
   );
 
-  // Período fiscal Abril 2026 (cubre la fecha de cancelación — "hoy" = 2026-04-01)
+  // Período fiscal Q2-Q4 2026 (cubre cualquier fecha de cancelación durante el año)
   // cancelInvoice busca un período OPEN para "today" al crear el asiento de reversión.
   await withRLSContext(prismaOwner, IDS.companyA, (tx) =>
     tx.fiscalPeriod.create({
@@ -247,9 +247,9 @@ beforeAll(async () => {
         companyId: IDS.companyA,
         fiscalYearId: IDS.fiscalYear,
         periodNumber: 4,
-        name: 'Abril 2026',
+        name: 'Abril-Diciembre 2026',
         startDate: new Date('2026-04-01'),
-        endDate: new Date('2026-04-30'),
+        endDate: new Date('2026-12-31'),
         status: 'OPEN',
       },
     }),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as middleware, config } from './proxy';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as middleware, config } from './proxy';


### PR DESCRIPTION
## Root cause

Commit `5b1931d` deleted `src/middleware.ts` under the incorrect assumption that Next.js 16 could pick up `proxy.ts` natively. Next.js **only** discovers middleware from `src/middleware.ts` (or root `middleware.ts`) — any other filename is ignored entirely.

Without `middleware.ts`, `proxy.ts` was never called:
- No JWT verification ran
- No `x-company-id` / `x-user-id` auth headers were injected into requests
- Every `/dashboard` hit had no valid token context → permanent redirect back to `/login`

## Fix

Restore `src/middleware.ts` with a single re-export line:

```ts
export { proxy as middleware, config } from './proxy';
```

This, combined with the CookieStorage fix from PR #27 (Amplify tokens now persisted as cookies instead of localStorage), completes the full auth flow:

1. User logs in → Amplify writes tokens to cookies
2. Browser requests `/dashboard` → `middleware.ts` runs `proxy.ts`
3. `proxy.ts` reads the `idToken` cookie → verifies JWT against Cognito JWKS
4. Auth headers injected → dashboard loads correctly

## Test plan

- [ ] Login with valid credentials → redirected to `/dashboard` without loop
- [ ] Manually navigate to `/dashboard` while logged in → stays on dashboard
- [ ] Manually navigate to `/dashboard` while logged out → redirected to `/login`
- [ ] API routes (`/api/v1/*`) return 401 JSON when no token present